### PR TITLE
Fix: pagination using unordered ids

### DIFF
--- a/packages/note/src/contexts/FieldGroupContext.tsx
+++ b/packages/note/src/contexts/FieldGroupContext.tsx
@@ -203,7 +203,7 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
       sentenceAudioField: sentenceAudioField ?? "",
       miscInfoField: miscInfoField ?? "",
       pictureField: pictureField ?? "",
-      ids: idsArray,
+      ids: sorted.map(String),
     };
   });
 


### PR DESCRIPTION
The [pagination](https://github.com/youyoumu/kiku/blob/6ccce4a2d23089f6cffc7b856c39e4ee2be45bd2/packages/note/src/lazy/components/FieldGroupPagination.tsx#L41) is using $group().ids to display the date corresponding to the current group id.
However, the $group().ids is the unsorted array while the field group context uses a sorted array. Therefore, the current group of the pagination is not the correct one.
The fix is to return the sorted array (remapped to strings).

Before Fix: 
<img width="442" height="381" alt="2026-08-01-164651_hyprshot" src="https://github.com/user-attachments/assets/4f05b45b-48ab-41c8-a151-9c98d680cc4d" />

After Fix: 
<img width="519" height="404" alt="2026-08-01-164842_hyprshot" src="https://github.com/user-attachments/assets/826b2885-a3b3-41f2-ad33-42ed2c08395c" />

Configuration: 
<img width="616" height="186" alt="2026-08-01-164701_hyprshot" src="https://github.com/user-attachments/assets/946464f2-ae9d-43db-9536-b3619cc09bba" />
