### PR TITLE
Feat: Add unindexed group

### DIFF
--- a/apps/docs/mds/field-grouping.md
+++ b/apps/docs/mds/field-grouping.md
@@ -127,3 +127,110 @@ The button is available on the top left corner when you visit nested notes.
 - If either note has empty **SentenceFurigana**, the target note's **SentenceFurigana** will be updated as empty.
 - Some special tags like `leech`, `marked`, `potential_leech` will not be added to the target note.
 - "Delete Root Note" option will be available when the root note is less than 1 day old. This option will delete the root note after merging.
+
+## Unindexed group
+
+If you want to automatically add notes through anki-connect (for example using yomitan), it's not easy to know which id to use to not overlap with any existing ids.
+In that case, you can use `data-group-id="unindexed"`.
+
+- Each group with id "unindexed" will be considered different.
+- Unindexed group are rendered sequentialy *after* explicitly indexed group
+- The n-th unindexed group of one field is matched with the n-th unindexed group of the other fields.
+- Therefore, there should be the same number of unindexed group in each field, if you want an empty field, you can create an empty span or image with the `data-group-id="unindexed"`.
+
+A card could look like this:
+
+::: details Fields {open}
+
+Picture:
+
+```html
+<img data-group-id="unindexed" src="shadow_house_screenshot_2026-07-03-14-23-59-392.jpeg">
+<img data-group-id="10" src="SubsPlease%20Tate%20no%20Yuusha%20no%20Nariagari%20S3%20-%2010%20(1080p)%20BCA53DD5.mkv_1190221.jpeg">
+<img data-group-id="unindexed" src="Anime_Time_Solo_Leveli_928960_pzThqpQf.jpeg">
+<img src="cbt%20gochuumon%20wa%20usagi%20desuka%20s01e09%20bdrip%201920x1080%20x264%20flac%209092049a.mkv_957803.webp">
+```
+
+Sentence:
+
+```html
+<span data-group-id="unindexed">偉大[いだい]なるおじいさまにもっと 貢献[こうけん]せねば</span>
+<span data-group-id="10">どうせ 勇者[ゆうしゃ]の 捕縛[ほばく]に<b> 貢献[こうけん]</b>すれば➡</span>
+<span data-group-id="unindexed">これで  少[すこ]しは<br> 世[よ]の 中[なか]に<b> 貢献[こうけん]</b>できるかな</span>
+このお 店[たな,みせ]に<b> 貢献[こうけん]</b>するために―
+```
+
+SentenceAudio:
+
+```html
+<span data-group-id="unindexed"></span>
+<span data-group-id="10">[sound:SubsPlease Tate no Yuusha no Nariagari S3 - 10 (1080p) BCA53DD5.mkv_118779-a512c7dd2b6572854ecfd7760d9f297cea529b66.mp3]</span>
+<span data-group-id="unindexed">[sound:Anime_Time_Solo_Leveli_925842_K4AlcB99.mp3]</span>
+[sound:CBT Gochuumon wa Usagi Desuka S01E09 BDrip 1920x1080 x264 FLAC 9092049A.mkv_955687.289_958481.289.mp3]
+```
+
+:::
+
+## Yomitan Setup
+
+Yomitan supports prepending/overwriting/appending to existing cards. We can configure it to use unindexed ids in order to automatically group the fields.
+
+1. Open your Yomitan settings, you will first need to enable advanced options in the bottom left corner
+
+2. Now, go to `Anki` > `Check for duplicates`, change the dropdown `When a duplicate is detected` to `allow overwriting`
+
+3. To inject the `data-group-id` attribute into the images created by the `{screenshot}` and `{clipboard-image}`, we need to add our own handlebar code to yomitan.
+    - Go to `Anki` > `Customize handlebars templates…`,
+    - Scroll down,
+    - paste the following code *before* <code v-pre>{{~> (lookup . "marker") ~}}</code>
+
+    ```
+    {{#*inline "clipboard-image-unindexed"}}
+        {{~#if (hasMedia "clipboardImage")~}}
+            <img data-group-id="unindexed" src="{{getMedia "clipboardImage"}}"/>
+        {{~else~}}
+            <img data-group-id="unindexed"/>
+        {{~/if~}}
+    {{/inline}}
+    
+    {{#*inline "screenshot-unindexed"}}
+        {{~#if (hasMedia "screenshot")~}}
+            <img data-group-id="unindexed" src="{{getMedia "screenshot"}}"/>
+        {{~else~}}
+            <img data-group-id="unindexed"/>
+        {{~/if~}}
+    {{/inline}}
+    ```
+
+    Now, we can use `{clipboard-image-unindexed}` and `{screenshot-unindexed}`.
+
+4. Finally, open `Anki` > `Configure Anki flashcard`, select `Kiku` as the Model, select your deck, and configure the following fields:
+
+
+| Field                 | Value                                                                                          |   Overwrite    |
+| --------------------- | -----------------------------------------------------------------------------------------------|----------------|
+| Expression            | `{expression}`                                                                                 | Fill if empty  |
+| ExpressionFurigana    | `{furigana-plain}`                                                                             | Fill if empty  |
+| ExpressionReading     | `{reading}`                                                                                    | Fill if empty  |
+| ExpressionAudio       | `{audio}`                                                                                      | Fill if empty  |
+| RelatedExpression     | (leave empty)                                                                                  | Skip           |
+| SelectionText         | `{popup-selection-text}`                                                                       | Prepend        |
+| MainDefinition        | Something like `{single-glossary-jmdict/jitendex}`                                             | Fill if empty  |
+| DefinitionPicture     | (leave empty)                                                                                  | Fill if empty  |
+| Sentence              | `<span data-group-id="unindexed">{cloze-prefix}<b>{cloze-body}</b>{cloze-suffix}</span>`       | Prepend        |
+| SentenceFurigana      | `<span data-group-id="unindexed">{sentence-furigana-plain}</span>`                             | Prepend        |
+| SentenceTranslation   | `<span data-group-id="unindexed"></span>`                                                      | Prepend        |
+| SentenceAudio         | `<span data-group-id="unindexed"></span>`                                                      | Prepend        |
+| Picture               | `{screenshot-unindexed}` OR `{clipboard-image-unindexed}` OR `<img data-group-id="unindexed">` | Prepend        |
+| Glossary              | `{glossary}`                                                                                   | Fill if empty  |
+| Hint                  | (leave empty)                                                                                  | Skip           |
+| IsWordAndSentenceCard | (leave empty)                                                                                  | Skip           |
+| IsClickCard           | (leave empty)                                                                                  | Skip           |
+| IsSentenceCard        | (leave empty)                                                                                  | Skip           |
+| IsAudioCard           | (leave empty)                                                                                  | Skip           |
+| PitchPosition         | `{pitch-accent-positions}`                                                                     | Fill if empty  |
+| PitchCategories       | `{pitch-accent-categories}`                                                                    | Fill if empty  |
+| Frequency             | `{frequencies}`                                                                                | Fill if empty  |
+| FreqSort              | `{frequency-harmonic-rank}`                                                                    | Fill if empty  |
+| MiscInfo              | `<span data-group-id="unindexed">{document-title}</span>`                                      | Prepend        |
+                                                                                                                                           

--- a/packages/note/src/contexts/FieldGroupContext.tsx
+++ b/packages/note/src/contexts/FieldGroupContext.tsx
@@ -70,9 +70,23 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
       $initialSide(),
     );
 
+    // unindexed group will be assigned negative index
+    // the n-th unindexed group of each fields will have index -n
+    //
+    // each fields should have the same amount of unindexed group
+    // you can't have
+    // field 1: <unindexed 1> <unindexed2> <unindexed3>
+    // field 2: <unindexed 1> <unindexed3>
+    // because there would be no way to know that it's the group 3
+    // though it should be fine if there's one field with more fields, but in the same order
+    let indexOfNextUnindexedGroup = -1;
     const sentenceFieldDoc = parseHtml($sentenceField());
     const sentenceFieldWithGroup = sentenceFieldDoc.querySelectorAll("[data-group-id]");
     sentenceFieldWithGroup.forEach((el) => {
+      if ((el as HTMLElement).dataset.groupId == "unindexed") {
+        (el as HTMLElement).dataset.groupId = indexOfNextUnindexedGroup.toString();
+        indexOfNextUnindexedGroup -= 1;
+      }
       addId((el as HTMLElement).dataset.groupId);
     });
 
@@ -81,10 +95,15 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
     );
     const sentenceFieldWithoutGroupHtml = nodesToString(sentenceFieldWithoutGroup);
 
+    indexOfNextUnindexedGroup = -1;
     const sentenceTranslationFieldDoc = parseHtml($sentenceTranslationField());
     const sentenceTranslationFieldWithGroup =
       sentenceTranslationFieldDoc.querySelectorAll("[data-group-id]");
     sentenceTranslationFieldWithGroup.forEach((el) => {
+      if ((el as HTMLElement).dataset.groupId == "unindexed") {
+        (el as HTMLElement).dataset.groupId = indexOfNextUnindexedGroup.toString();
+        indexOfNextUnindexedGroup -= 1;
+      }
       addId((el as HTMLElement).dataset.groupId);
     });
 
@@ -95,9 +114,14 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
       sentenceTranslationFieldWithoutGroup,
     );
 
+    indexOfNextUnindexedGroup = -1;
     const sentenceAudioFieldDoc = parseHtml($sentenceAudioField());
     const sentenceAudioFieldWithGroup = sentenceAudioFieldDoc.querySelectorAll("[data-group-id]");
     sentenceAudioFieldWithGroup.forEach((el) => {
+      if ((el as HTMLElement).dataset.groupId == "unindexed") {
+        (el as HTMLElement).dataset.groupId = indexOfNextUnindexedGroup.toString();
+        indexOfNextUnindexedGroup -= 1;
+      }
       addId((el as HTMLElement).dataset.groupId);
     });
 
@@ -106,9 +130,14 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
     );
     const sentenceAudioFieldWithoutGroupHtml = nodesToString(sentenceAudioFieldWithoutGroup);
 
+    indexOfNextUnindexedGroup = -1;
     const miscInfoFieldDoc = parseHtml($miscInfoField());
     const miscInfoFieldWithGroup = miscInfoFieldDoc.querySelectorAll("[data-group-id]");
     miscInfoFieldWithGroup.forEach((el) => {
+      if ((el as HTMLElement).dataset.groupId == "unindexed") {
+        (el as HTMLElement).dataset.groupId = indexOfNextUnindexedGroup.toString();
+        indexOfNextUnindexedGroup -= 1;
+      }
       addId((el as HTMLElement).dataset.groupId);
     });
 
@@ -118,6 +147,7 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
     const miscInfoFieldWithoutGroupHtml = nodesToString(miscInfoFieldWithoutGroup);
 
     // each group may contain multiple img. img without group id will be given group id 0
+    indexOfNextUnindexedGroup = -1;
     const pictureFieldDoc = parseHtml($pictureField());
     const pictureFieldWithGroup = pictureFieldDoc.querySelectorAll("img");
     pictureFieldWithGroup.forEach((el) => {
@@ -125,6 +155,10 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
       if (!id) {
         id = "0";
         el.dataset.groupId = id;
+      } else if (id == "unindexed") {
+        id = indexOfNextUnindexedGroup.toString();
+        el.dataset.groupId = id;
+        indexOfNextUnindexedGroup -= 1;
       }
       addId(id);
     });
@@ -149,7 +183,17 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
     const idsArray = Array.from(ids);
     if (idsArray.length === 0) return $defaultGroup();
 
-    const sorted = idsArray.map((id) => Number(id)).sort((a, b) => b - a);
+    const sorted = idsArray.map((id) => Number(id)).sort((a, b) => {
+      // so that the ungrouped one is always last
+      if (b == 0) {
+        return -1;
+      } else if (a == 0) {
+        return 1;
+      } else {
+        // positive indexed group will be first, negative "unindexed" will come after
+        return b - a;
+      }
+    });
     const index = $index();
     const selectedId = sorted[index] ?? sorted[0];
     logger.info("[Groups] selected:", {
@@ -171,7 +215,7 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
     let miscInfoField: string | undefined;
     let pictureField: string | undefined;
 
-    if (selectedId > 0) {
+    if (selectedId != 0) {
       sentenceField = filterById(sentenceFieldWithGroup);
       sentenceTranslationField = filterById(sentenceTranslationFieldWithGroup);
       sentenceAudioField = filterById(sentenceAudioFieldWithGroup);

--- a/packages/note/src/contexts/FieldGroupContext.tsx
+++ b/packages/note/src/contexts/FieldGroupContext.tsx
@@ -168,7 +168,7 @@ export function FieldGroupContextProvider(props: { children: JSX.Element }) {
     if (
       !Array.from(ids)
         .map(Number)
-        .some((id) => id <= 0) &&
+        .some((id) => id == 0) &&
       (sentenceFieldWithoutGroupHtml.trim() ||
         sentenceTranslationFieldWithoutGroupHtml.trim() ||
         sentenceAudioFieldWithoutGroupHtml.trim() ||

--- a/packages/note/src/lazy/lib/merge-context.ts
+++ b/packages/note/src/lazy/lib/merge-context.ts
@@ -54,6 +54,18 @@ export function mergeContext(base: ContextField, extra: ContextField): ContextFi
     return Array.from(items).sort((a, b) => {
       const aId = Number((a as HTMLSpanElement).dataset.groupId);
       const bId = Number((b as HTMLSpanElement).dataset.groupId);
+
+      // "unindexed" ids will be NaN
+      const aIsNaN = Number.isNaN(aId);
+      const bIsNaN = Number.isNaN(bId);
+
+      if (aIsNaN && !bIsNaN) {
+        return 1;
+      } else if (!aIsNaN && bIsNaN) {
+        return -1;
+      } else if (aIsNaN && bIsNaN) {
+        return 0;
+      }
       return bId - aId;
     });
   }
@@ -92,11 +104,11 @@ export function normalizeFields(fields: ContextField): ContextField {
 
   //oxfmt-ignore
   const withoutGroup = {
-    sentence: Array.from(doc.sentence.body.childNodes).filter( (el) => !(el as HTMLSpanElement).dataset?.groupId,),
-    sentenceTranslation: Array.from(doc.sentenceTranslation.body.childNodes).filter( (el) => !(el as HTMLSpanElement).dataset?.groupId,),
-    sentenceFurigana: Array.from(doc.sentenceFurigana.body.childNodes).filter( (el) => !(el as HTMLSpanElement).dataset?.groupId,),
-    sentenceAudio: Array.from(doc.sentenceAudio.body.childNodes).filter( (el) => !(el as HTMLSpanElement).dataset?.groupId,),
-    miscInfo: Array.from(doc.miscInfo.body.childNodes).filter( (el) => !(el as HTMLSpanElement).dataset?.groupId,),
+    sentence: Array.from(doc.sentence.body.childNodes).filter((el) => !(el as HTMLSpanElement).dataset?.groupId,),
+    sentenceTranslation: Array.from(doc.sentenceTranslation.body.childNodes).filter((el) => !(el as HTMLSpanElement).dataset?.groupId,),
+    sentenceFurigana: Array.from(doc.sentenceFurigana.body.childNodes).filter((el) => !(el as HTMLSpanElement).dataset?.groupId,),
+    sentenceAudio: Array.from(doc.sentenceAudio.body.childNodes).filter((el) => !(el as HTMLSpanElement).dataset?.groupId,),
+    miscInfo: Array.from(doc.miscInfo.body.childNodes).filter((el) => !(el as HTMLSpanElement).dataset?.groupId,),
     picture: Array.from(doc.picture.querySelectorAll("img:not([data-group-id])")),
   };
 
@@ -153,8 +165,11 @@ export function parseMergedIntoReadable(fields: ContextField) {
       .map((node) => {
         const groupId = node.getAttribute("data-group-id");
         if (!groupId) return null;
-        if (seen.has(groupId)) duplicates.add(groupId);
-        else seen.add(groupId);
+        // Don't check for duplicate if it's unindexed
+        if (groupId != "unindexed") {
+          if (seen.has(groupId)) duplicates.add(groupId);
+          else seen.add(groupId);
+        }
         return `${groupId}: ${value(node)}`;
       })
       .filter(Boolean) as string[];
@@ -168,9 +183,9 @@ export function parseMergedIntoReadable(fields: ContextField) {
   // oxfmt-ignore
   const result = {
     sentence: extractGroupedText(fields.Sentence, "[data-group-id]", (n) => n.textContent),
-    sentenceTranslation: extractGroupedText( fields.SentenceTranslation, "[data-group-id]", (n) => n.textContent,),
-    sentenceFurigana: extractGroupedText( fields.SentenceFurigana, "[data-group-id]", (n) => n.textContent,),
-    sentenceAudio: extractGroupedText( fields.SentenceAudio, "[data-group-id]", (n) => n.textContent,),
+    sentenceTranslation: extractGroupedText(fields.SentenceTranslation, "[data-group-id]", (n) => n.textContent,),
+    sentenceFurigana: extractGroupedText(fields.SentenceFurigana, "[data-group-id]", (n) => n.textContent,),
+    sentenceAudio: extractGroupedText(fields.SentenceAudio, "[data-group-id]", (n) => n.textContent,),
     miscInfo: extractGroupedText(fields.MiscInfo, "[data-group-id]", (n) => n.textContent),
     picture: extractGroupedText(fields.Picture, "img[data-group-id]", (n) => n.getAttribute("src")),
   };


### PR DESCRIPTION
## What?
It adds "unindexed" group. Those group don't need an id and there can be multiple of them. The n-th group of one field is paired with the n-th group of the other fields. 
The order is, after any indexed group, but before the un-grouped elements. The first unindexed group comes first.
The syntax is just `data-group-id="unindexed"`

## Why?
I think something like senren `class="group"` would be great because yomitan support prepending, appending or overwriting cards. This could work well with the group feature. However, with the current setup, you would need to change the id of the group. This is not easily possible.
The fix would be to add those unindexed group. 
Now, you can directly append or prepend `<span date-group-id="unindexed">{sentence}</span>`

## How?
The n-th unindexed group of one field is paired with the n-th unindexed group of the other fields.
Therefore they should have the same amount of unindexed group.
### Dispay
In [Field Group Context](https://github.com/ch-dewez/kiku/blob/52580294b859d5e72bbd761a7984ab4cd82e0506/packages/note/src/contexts/FieldGroupContext.tsx#L73), I assign a negative index to each of them (-1 for the first one, then it decreases). After they are sorted, they are treated exactly like any other grouped field.
### Merging
I don't do anything in the [normalization of the field](https://github.com/ch-dewez/kiku/blob/52580294b859d5e72bbd761a7984ab4cd82e0506/packages/note/src/lazy/lib/merge-context.ts#L84) because we want the merged note to keep the unindexed group.
When, after the merge, we want to [sort the group](https://github.com/ch-dewez/kiku/blob/52580294b859d5e72bbd761a7984ab4cd82e0506/packages/note/src/lazy/lib/merge-context.ts#L53), I make sure to rank them at the bottom
Finally, I remove the [check for duplicates](https://github.com/ch-dewez/kiku/blob/52580294b859d5e72bbd761a7984ab4cd82e0506/packages/note/src/lazy/lib/merge-context.ts#L168) if the group id is "unindexed".

## Example
<img width="573" height="165" alt="image" src="https://github.com/user-attachments/assets/926ad7fd-3834-4a28-98fe-dcba3756698d" />

## AI
I didn't use AI to write the code nor to write this PR, but I did a review with it. 
Though, with my level, AI might not be a bad thing :sweat_smile: 

Also I hope I didn't misinterpret anything in logic of the merging or anywhere else. : )